### PR TITLE
support Rails 7.1 more by fixing serialize arguments

### DIFF
--- a/lib/settings_on_rails/configuration.rb
+++ b/lib/settings_on_rails/configuration.rb
@@ -14,7 +14,12 @@ module SettingsOnRails
       klass.class_eval do
         class_attribute Configuration::NAME_COLUMN, Configuration::DEFAULTS_COLUMN
 
-        serialize column, ActiveSupport::HashWithIndifferentAccess
+        if ActiveRecord.version > Gem::Version.new('7.1')
+          serialize column, type: ActiveSupport::HashWithIndifferentAccess, coder: YAML
+        else
+          serialize column, ActiveSupport::HashWithIndifferentAccess
+        end
+
         Configuration::init_defaults_column(self)
         Configuration::init_name_column(self, column)
       end


### PR DESCRIPTION
What has been tested to be compatible with this PR:
- Rails 6.0, 6.1, 7.0, 7.1
- Ruby 3.0, 3.1, 3.2